### PR TITLE
Fix Docker base images being switched by Renovate

### DIFF
--- a/default.json
+++ b/default.json
@@ -29,8 +29,15 @@
       "matchDatasources": [
         "docker"
       ],
-      "minimumReleaseAge": "1 day",
-      "versioning": "digest",
+      "minimumReleaseAge": "1 day"
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
       "automerge": true
     },
     {


### PR DESCRIPTION
The blanket docker rule set `versioning: digest` and an unconditional `automerge: true`. Both were too broad:

- `versioning: digest` replaced default `docker` versioning, which is what keeps a tag's compatibility part (`alpine3.24`) from changing. Without it, harryzcy/container-images#909 proposed `3.14.6-alpine3.24` → `3.14.7`, switching that image from Alpine to Debian; only the build failure stopped it automerging.
- `automerge: true` covered all update types, and `packageRules` are re-applied after the update-type merge — so it overrode `major: {"automerge": false}` and docker major bumps were automerging.

Drop the `versioning` override; scope `automerge` to `matchUpdateTypes: ["digest"]`. Docker major now needs review; patch/minor still automerge via `:automergeMinor`.
