### PR TITLE
Group golang.org/x dependencies together

### DIFF
--- a/default.json
+++ b/default.json
@@ -56,6 +56,15 @@
       "enabled": true
     },
     {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "golang.org/x/**"
+      ],
+      "groupName": "golang.org/x"
+    },
+    {
       "matchDatasources": [
         "github-digest"
       ],


### PR DESCRIPTION
Groups all `golang.org/x/*` gomod updates into a single PR. They share a release cadence and depend on each other, so separate PRs overlap — an update to one often bumps another in the same branch.