### PR TITLE
Enable OSV vulnerability alerts and label security PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -85,5 +85,13 @@
     "gomodTidy",
     "gomodUpdateImportPaths",
     "npmDedupe"
-  ]
+  ],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "dependencies",
+      "security"
+    ]
+  }
 }


### PR DESCRIPTION
`vulnerabilityAlerts` is on by default but sources only from GitHub's Dependabot alerts API, which silently missed nanoid twice on harryzcy.github.io. `osvVulnerabilityAlerts` (default `false`) makes Renovate query OSV directly.

Inherited defaults already suit security PRs: `minimumReleaseAge: null`, `rangeStrategy: update-lockfile`, `prCreation: immediate`. No `automerge` here — `:automergeMinor` already covers patch/minor, and adding it would override `major.automerge: false`.
